### PR TITLE
Dockerfile: group commands to decrease image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,30 +3,28 @@ MAINTAINER Flávio Ribeiro <email@flavioribeiro.com>
 
 # Update apt and install dependencies with multiverse
 RUN sh -c "echo 'deb http://us.archive.ubuntu.com/ubuntu trusty main multiverse' >> /etc/apt/sources.list"
-RUN apt-get update -qq
-RUN apt-get install --force-yes -y -qq libfaac-dev libgpac-dev libmp3lame-dev libjpeg-turbo8-dev libtheora-dev \
-  libvorbis-dev libx264-dev libvlccore-dev libvlc-dev git build-essential yasm curl
+RUN apt-get update -qq && apt-get install --force-yes -y -qq libfaac-dev libgpac-dev libmp3lame-dev libjpeg-turbo8-dev libtheora-dev \
+  libvorbis-dev libx264-dev libvlccore-dev libvlc-dev git build-essential yasm curl && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install libvpx with VP8/VP9 support
-RUN git clone --depth=1 https://chromium.googlesource.com/webm/libvpx
-RUN cd libvpx && ./configure --enable-shared && make -j `grep processor /proc/cpuinfo|wc -l` && make install
+RUN git clone --depth=1 https://chromium.googlesource.com/webm/libvpx && \
+  cd libvpx && ./configure --enable-shared && make -j `grep processor /proc/cpuinfo|wc -l` && make install && \
+  rm -rf libvpx
 
 # Install ffmpeg with libvpx and enable-shared
-RUN git clone --depth=1 git://source.ffmpeg.org/ffmpeg.git
-RUN cd ffmpeg && ./configure --enable-shared --enable-swscale --enable-gpl  --enable-libx264 --enable-libvpx \
-  --enable-libvorbis --enable-libtheora && make -j `grep processor /proc/cpuinfo|wc -l` && make install
+RUN git clone --depth=1 git://source.ffmpeg.org/ffmpeg.git && \
+  cd ffmpeg && ./configure --enable-shared --enable-swscale --enable-gpl  --enable-libx264 --enable-libvpx \
+  --enable-libvorbis --enable-libtheora && make -j `grep processor /proc/cpuinfo|wc -l` && make install && \
+  rm -rf ffmpeg
 
 # Install Go
-RUN curl -O https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz
-RUN tar -xvzf go1.6.linux-amd64.tar.gz
-RUN mv go /usr/local
-RUN mkdir /go
+RUN curl -L https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
+  mkdir /go
 
 # Set environment variables for go
-ENV GOPATH /go
-ENV GOROOT /usr/local/go
+ENV GOPATH=/go GOROOT=/usr/local/go
 ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
+
 RUN sh -c "echo '/usr/local/lib' >> /etc/ld.so.conf"
 RUN ldconfig
-RUN rm -rf ffmpeg libvpx go1.6.linux-amd64.tar.gz
-RUN rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Flávio Ribeiro <email@flavioribeiro.com>
 # Update apt and install dependencies with multiverse
 RUN sh -c "echo 'deb http://us.archive.ubuntu.com/ubuntu trusty main multiverse' >> /etc/apt/sources.list"
 RUN apt-get update -qq && apt-get install --force-yes -y -qq libfaac-dev libgpac-dev libmp3lame-dev libjpeg-turbo8-dev libtheora-dev \
-  libvorbis-dev libx264-dev libvlccore-dev libvlc-dev git build-essential yasm curl && \
+  libvorbis-dev libx264-dev libvlccore-dev libvlc-dev git make cmake yasm curl && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install libvpx with VP8/VP9 support


### PR DESCRIPTION
I'm grouping some commands, so their filesystem changes are "locked" to a
single image layer.

Before this change: 2.164 GB
After this change: 1.737 GB

We can probably make it even smaller by using Alpine instead of Ubuntu as the
base image.

Related to #1.
